### PR TITLE
FIX: create db schema always in memory db when execute tests

### DIFF
--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-spring.jpa.properties.hibernate.default_schema=mega_horoscopo
+spring.jpa.properties.hibernate.default_schema=MEGA_HOROSCOPO
 spring.datasource.initialization-mode=always
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql: false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -6,6 +6,7 @@ spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 spring.jpa.properties.hibernate.default_schema=mega_horoscopo
+spring.datasource.initialization-mode=always
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql: false
 

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,11 +1,11 @@
 # Database configuration
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:testdb;INIT=CREATE SCHEMA IF NOT EXISTS mega_horoscopo\\;SET SCHEMA mega_horoscopo;
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-spring.jpa.properties.hibernate.default_schema=MEGA_HOROSCOPO
+spring.jpa.properties.hibernate.default_schema=mega_horoscopo
 spring.datasource.initialization-mode=always
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql: false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-spring.jpa.properties.hibernate.default_schema=mega_horoscopo
+spring.jpa.properties.hibernate.default_schema=MEGA_HOROSCOPO
 spring.datasource.initialization-mode=always
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql: false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,8 +5,8 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-spring.jpa.properties.hibernate.default_schema=MEGA_HOROSCOPO
+spring.jpa.properties.hibernate.default_schema=mega_horoscopo
 spring.datasource.initialization-mode=always
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql: false
 


### PR DESCRIPTION
Pull Request to merge into develop one fix to avoid errors of schema not exists when unit tests are execued